### PR TITLE
Rename images-molecules.zip, not .csv

### DIFF
--- a/client/src/pages/Admin.js
+++ b/client/src/pages/Admin.js
@@ -343,7 +343,7 @@ const Admin = () => {
         <summary>Importer des images</summary>
         <FileDownloader
           text="Télécharger les dernières images importées"
-          filename="images-molecules.csv"
+          filename="images-molecules.zip"
           endpoint="/api/v1/import/images"
         />
         <FileImporter


### PR DESCRIPTION
## Changes

<!--
 List all the changes made to the code. Add unticked items if some work has to be done
 Remove non applicable items
-->

- [x] The zipped folder of images downloaded from the admin panel was named `.csv` by the client, but this is a `.zip`.

(this PR is not tested, hope that everything will happen as expected. I thinked about moving 10-20 files in addition of the one line change, but I don't have the time ATM).