### PR TITLE
Fix for good the cache of duelCreate

### DIFF
--- a/client/src/utils/configuredQueryClient.js
+++ b/client/src/utils/configuredQueryClient.js
@@ -39,7 +39,8 @@ queryClient.setQueryDefaults("duels", {
 
 queryClient.setQueryDefaults(["users", "challengeable"], {
   queryFn: getChallengeableUsers,
-  staleTime: 60 * 60 * 1000,
+  staleTime: 60 * 1000,
+  refetchOnMount: "always",
 });
 
 export default queryClient;

--- a/client/src/utils/queryUsers.js
+++ b/client/src/utils/queryUsers.js
@@ -15,6 +15,6 @@ export function makeGetUserInfo(username) {
  * @returns {Promise<Array>} An array with all the users that we can challenge
  */
 export async function getChallengeableUsers() {
-  const { data } = await axios.get("/api/v1/users?challengeable=true");
+  const { data } = await axios.get("/api/v1/users/?challengeable=true");
   return data;
 }


### PR DESCRIPTION
## Changes

<!--
 List all the changes made to the code. Add unticked items if some work has to be done
 Remove non applicable items
-->

- [x] Always refetch the challengeables users when mouting the DuelCreate component.

This is the solution that really closes #230.