### PR TITLE
Choose the database used according to the NODE_ENV

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -77,7 +77,7 @@ jobs:
           echo "REFRESH_TOKEN_KEY=TMP_REFRESH_KEY" >> .env; \
           echo "DB_HOST=localhost" >> .env; \
           echo "DB_USER=guacamoleUser" >> .env; \
-          echo "DB_PASSWORD=p@assword" >> .env; \
+          echo "DB_PASSWORD=p@ssword" >> .env; \
           echo "DB_DATABASE_TEST=guacamoleTestDb" >> .env; \
 
         working-directory: ./server

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -72,7 +72,14 @@ jobs:
         working-directory: ./server
 
       - name: Setting private key
-        run: echo "ACCESS_TOKEN_KEY=TMP_ACCESS_KEY" >> .env; echo "REFRESH_TOKEN_KEY=TMP_REFRESH_KEY" >> .env;
+        run: |
+          echo "ACCESS_TOKEN_KEY=TMP_ACCESS_KEY" >> .env; \
+          echo "REFRESH_TOKEN_KEY=TMP_REFRESH_KEY" >> .env; \
+          echo "DB_HOST=localhost" >> .env; \
+          echo "DB_USER=guacamoleUser" >> .env; \
+          echo "DB_PASSWORD=p@assword" >> .env; \
+          echo "DB_DATABASE_TEST=guacamoleTestDb" >> .env; \
+
         working-directory: ./server
 
       - name: Wait for mariadb server to be ready

--- a/server/db/database.js
+++ b/server/db/database.js
@@ -35,11 +35,13 @@ const versions = [
  */
 export const currentAPIVersion = () => versions[versions.length - 1];
 
+const { NODE_ENV, DB_DATABASE, DB_DATABASE_TEST, DB_HOST, DB_PASSWORD, DB_USER } = process.env;
+
 export const connection = mysql.createConnection({
-  host: process.env.DB_HOST || "localhost",
-  user: process.env.DB_USER || "guacamoleUser",
-  password: process.env.DB_PASSWORD || "p@ssword",
-  database: process.env.DB_DATABASE || "guacamoleDb",
+  host: DB_HOST,
+  user: DB_USER,
+  password: DB_PASSWORD,
+  database: NODE_ENV === "test" ? DB_DATABASE_TEST : DB_DATABASE,
   multipleStatements: true,
 });
 

--- a/server/index.js
+++ b/server/index.js
@@ -67,7 +67,14 @@ app.waitReady = function (callback, interval = 100) {
  */
 function checkEnv() {
   let needToExit = false;
-  const keys = ["ACCESS_TOKEN_KEY", "REFRESH_TOKEN_KEY"];
+  const keys = [
+    "ACCESS_TOKEN_KEY",
+    "REFRESH_TOKEN_KEY",
+    "DB_HOST",
+    "DB_USER",
+    "DB_PASSWORD",
+    process.env.NODE_ENV === "test" ? "DB_DATABASE_TEST" : "DB_DATABASE",
+  ];
   for (const key of keys) {
     if (!process.env[key]) {
       Logger.error(

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "NODE_ENV=test DB_DATABASE=guacamoleTestDb PORT=5036 mocha \"test/**/*.test.js\" --exit",
+    "test": "NODE_ENV=test PORT=5036 mocha \"test/**/*.test.js\" --exit",
     "test:generate-data": "NODE_ENV=test PORT=5037 node ./db/fill-fake-data.js",
     "start": "node .",
     "start:watch": "nodemon .",


### PR DESCRIPTION
## Changes

Currently, we explicitly define the special database in the `npm test` script, but this type of information should not be common and imposed on all developers as this is the local development environment.

The database used is now chosen from the `.env`, according to the NODE_ENV value.

I also removed the default value from the environment variable as they cannot be forgotten to start the server.